### PR TITLE
Connect to DB in background and avoid exitting on query error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 ## Available workloads
 
+- Health: Returns 200. Does not need postgres connectivity. Available at `/health`
 - Ready: Inserts a timestamp record in the ts table. Available at `/ready`
 - Euler aproximation: Computes an Euler number approximation and writes compute time in the euler table. Available at `/euler`

--- a/internal/perf/db.go
+++ b/internal/perf/db.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	_ "github.com/lib/pq"
-	"github.com/rsevilla87/perfapp/pkg/utils"
 )
 
 // DBInfo Database connection information
@@ -60,7 +59,7 @@ func QueryDB(query string) error {
 		return err
 	}
 	if _, err := DB.conn.Exec(query); err != nil {
-		utils.ErrorHandler(err)
+		return err
 	}
 	return nil
 }

--- a/pkg/euler/euler.go
+++ b/pkg/euler/euler.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/rsevilla87/perfapp/internal/perf"
-	"github.com/rsevilla87/perfapp/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,14 +18,14 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	log.Println("Computing euler approximation")
 	now := time.Now()
 	calcEuler()
-	elapsed := time.Now().Sub(now)
-	insert := fmt.Sprintf("INSERT INTO euler VALUES ('%s', '%f')", now.Format(time.RFC3339), elapsed.Seconds())
+	insert := fmt.Sprintf("INSERT INTO euler VALUES ('%s', '%f')", now.Format(time.RFC3339), time.Since(now).Seconds())
 	if err := perf.QueryDB(insert); err != nil {
-		utils.ErrorHandler(err)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintln(w, err.Error())
 	} else {
 		fmt.Fprintln(w, "Ok")
-		log.Printf("Euler approximation computed in %f seconds", elapsed.Seconds())
-		perf.HTTPRequestDuration.Observe(elapsed.Seconds())
+		log.Printf("Euler approximation computed in %f seconds", time.Since(now).Seconds())
+		perf.HTTPRequestDuration.Observe(time.Since(now).Seconds())
 	}
 }
 
@@ -37,5 +36,4 @@ func calcEuler() {
 		x = math.Pow((1 + 1/n), n)
 		n++
 	}
-	return
 }

--- a/pkg/ready/timestamp.go
+++ b/pkg/ready/timestamp.go
@@ -1,4 +1,4 @@
-package timestamp
+package ready
 
 import (
 	"fmt"
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/rsevilla87/perfapp/internal/perf"
-	"github.com/rsevilla87/perfapp/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -17,13 +16,13 @@ var Tables = map[string]string{"ts": "CREATE TABLE IF NOT EXISTS ts (date TIMEST
 func Handler(w http.ResponseWriter, r *http.Request) {
 	log.Info("Inserting timestamp record in table")
 	now := time.Now()
-	elapsed := time.Now().Sub(now)
 	insert := fmt.Sprintf("INSERT INTO ts VALUES ('%s')", now.Format(time.RFC3339))
 	if err := perf.QueryDB(insert); err != nil {
-		utils.ErrorHandler(err)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprintln(w, err.Error())
 	} else {
 		fmt.Fprintln(w, "Ok")
-		log.Printf("Timestamp inserted in %v ns", elapsed.Nanoseconds())
-		perf.HTTPRequestDuration.Observe(elapsed.Seconds())
+		log.Printf("Timestamp inserted in %v ns", time.Since(now).Nanoseconds())
+		perf.HTTPRequestDuration.Observe(time.Since(now).Seconds())
 	}
 }


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

# Description

With the original implementation, the client does not serve the endpoint `/health` unless the application is connected with PosgreSQL. This is not the desired behaviour, since, for example, the node-density-heavy workload has a livenessProbe that uses this endpoint, hence is more very likely to end up restarting some containers/pods in heavy load scenarios.


With the changes proposed here, the application is able to serve `/health` regardless it has established connection with the database or not.

**Results in node-density-heavy might be affected, as we will likely observe fewer pod restarts**

cc: @afcollins @smalleni @mohit-sheth @dry
